### PR TITLE
Fix logic error in Spotify Card

### DIFF
--- a/src/routes/utils/spotify-card.ts
+++ b/src/routes/utils/spotify-card.ts
@@ -62,8 +62,8 @@ export default async (req: Request, res: Response): Promise<any> => {
         const end = req.query.end;
         const title = req.query.title;
 
-        if (!isNaN(Number(start))) return ResponseUtil.badRequest(res, "start must be a number");
-        if (!isNaN(Number(end))) return ResponseUtil.badRequest(res, "end must be a number");
+        if (isNaN(Number(start))) return ResponseUtil.badRequest(res, "start must be a number");
+        if (isNaN(Number(end))) return ResponseUtil.badRequest(res, "end must be a number");
 
         if (!image || !author || !album || !start || !end || !title) {
             return ResponseUtil.missingParams(res, "image", "author", "album", "start", "end", "title");


### PR DESCRIPTION
this logic error prevent users from sending a valid number in req.query.start and .end